### PR TITLE
Bug fixing: bug on build/src/outputSummaryData.cpp and external potential in lattice units

### DIFF
--- a/build/src/latextv.cpp
+++ b/build/src/latextv.cpp
@@ -221,7 +221,7 @@ dcomp read_latext_v(int sx, int sy, int sz)
         -0.385/(A*r) + ltv_data.adj_sigma*(A*r); 
   }
   
-  return aVeff;
+  return aVeff/A;
 }
 
 void charge_latext_v(const char *filename)

--- a/build/src/outputroutines.cpp
+++ b/build/src/outputroutines.cpp
@@ -115,7 +115,7 @@ void outputSummaryData(string label, const double time, const int step) {
       out << NUM << "\t";
       out << A << "\t";
       out << MASS << "\t";
-      out << SIGMA << "\t";
+      out << SIGMA << endl;
       out.close();
 }
 


### PR DESCRIPTION
The following bugs have been fixed:

- The external potential is in lattice units (dimensionless), NOT in GeV.
- Removing bug on build/src/outputSummaryData.cpp
This bug was introduced on commit
f109dea8373404baf6b3f2a09758e3ff0b766c3b
Such a bug removed all new lines characters on *.out measurements files,
breaking quantumfdtd class on scripts/quantumfdtd.py

